### PR TITLE
2022.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@
 #### springcloud_etudent_eureka_2002 eureka注册中心2
 #### springcloud_etudent_eureka_2003 eureka注册中心3
 
+
+
+
+
+
+# 分支介绍
+## 2022分支 从基础搭建到Hystrix熔断降级
+## 2022.1 分支 Hystrix,feign 整合使用 实现彻底解耦

--- a/springcloud_student_parent/springcloud_student_common/src/main/java/com/etjava/service/StudentClientFallbackFactory.java
+++ b/springcloud_student_parent/springcloud_student_common/src/main/java/com/etjava/service/StudentClientFallbackFactory.java
@@ -1,0 +1,64 @@
+package com.etjava.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.etjava.entity.Student;
+
+import feign.hystrix.FallbackFactory;
+
+/**
+ * 	解耦服务熔断服务降级 - 配置服务降级
+ * 	当出现调用异常(超时，网络延迟等)会调用这里实现的方法
+ * @author etjav
+ *
+ */
+@Component
+public class StudentClientFallbackFactory implements FallbackFactory<StudentServiceWithFeign>{
+
+	
+	// 当出现调用异常(超时，网络延迟等)会调用这里实现的方法
+	@Override
+	public StudentServiceWithFeign create(Throwable cause) {
+		return new StudentServiceWithFeign() {
+
+			@Override
+			public Student get(Integer id) {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public List<Student> list() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public boolean save(Student student) {
+				// TODO Auto-generated method stub
+				return false;
+			}
+
+			@Override
+			public boolean delete(Integer id) {
+				// TODO Auto-generated method stub
+				return false;
+			}
+
+			// 当调用getInfo出现异常时 会调用这里的降级方法
+			@Override
+			public Map<String, Object> getInfo() {
+				Map<String,Object> map=new HashMap<String,Object>();
+                map.put("code", 500);
+                map.put("info", "系统出错，稍后重试");
+                return map;
+			}
+			
+		};
+	}
+
+}

--- a/springcloud_student_parent/springcloud_student_common/src/main/java/com/etjava/service/StudentServiceWithFeign.java
+++ b/springcloud_student_parent/springcloud_student_common/src/main/java/com/etjava/service/StudentServiceWithFeign.java
@@ -1,6 +1,7 @@
 package com.etjava.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,10 +15,12 @@ import com.etjava.entity.Student;
  *	@FeignClient(value="STUDENT-PROVIDER")	该接口需要指定访问的实例名称 即 application.name 不需要填写http:// 底层封装了
  *	底层实现由feign帮着实现了 类似MybatisPlus
  *  	
+ * fallbackFactory=StudentClientFallbackFactory.class
+ * 	当出现异常时的回调类 这里配置的类就是实现降级处理的类 也就是实现了FallbackFactory的类
  * @author etjav
  *
  */
-@FeignClient(value="STUDENT-PROVIDER")
+@FeignClient(value="STUDENT-PROVIDER",fallbackFactory=StudentClientFallbackFactory.class)
 public interface StudentServiceWithFeign {
 
 	 /**
@@ -49,5 +52,12 @@ public interface StudentServiceWithFeign {
      */
     @GetMapping(value="/student/delete/{id}")
     public boolean delete(@PathVariable("id") Integer id);
+    
+    /**
+     * 	模拟hystrix熔断降级
+     * @return
+     */
+    @GetMapping(value="/student/getInfo")
+    public Map<String,Object> getInfo();
 	
 }

--- a/springcloud_student_parent/springcloud_student_consumer_feign_80/src/main/java/com/etjava/controller/StudentConsumerController.java
+++ b/springcloud_student_parent/springcloud_student_consumer_feign_80/src/main/java/com/etjava/controller/StudentConsumerController.java
@@ -1,6 +1,7 @@
 package com.etjava.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.etjava.entity.Student;
@@ -65,5 +67,15 @@ public class StudentConsumerController {
     @GetMapping(value="/delete/{id}")
     public boolean delete(@PathVariable("id") Integer id){
     	return studentServiceWithFeign.delete(id);
+    }
+    
+    /**
+     * 	模拟Hystrix熔断和降级处理
+     * @return
+     */
+    @GetMapping(value="/getInfo")
+    @ResponseBody
+    public Map<String,Object> getInfo(){
+        return studentServiceWithFeign.getInfo();
     }
 }

--- a/springcloud_student_parent/springcloud_student_consumer_feign_80/src/main/resources/application.yml
+++ b/springcloud_student_parent/springcloud_student_consumer_feign_80/src/main/resources/application.yml
@@ -11,7 +11,10 @@ eureka:
       defaultZone: http://eureka2001.etjava.com:2001/eureka/,
                     http://eureka2002.etjava.com:2002/eureka/,
                     http://eureka2003.etjava.com:2003/eureka/
-
+# 开启hystrix断路器
+feign: 
+  hystrix: 
+    enabled: true
 
 # 单机 需要指定服务提供者的IP+端口
 # provider_host: http://localhost:1001

--- a/springcloud_student_parent/springcloud_student_provider_hystrix_1004/src/main/java/com/etjava/controller/StudentController.java
+++ b/springcloud_student_parent/springcloud_student_provider_hystrix_1004/src/main/java/com/etjava/controller/StudentController.java
@@ -79,26 +79,39 @@ public class StudentController {
         }
     }
     
-    /**
+    /** 
+     * 	这里通过feign+hystrix进行解耦
      * 	获取信息
+     * @return
+     * @throws InterruptedException 
+     */
+//    @ResponseBody
+//    @GetMapping(value="/getInfo")
+//    @HystrixCommand(fallbackMethod="getInfoFallback")
+//    public Map<String,Object> getInfo() throws InterruptedException{
+//        Thread.sleep(1000);
+//        Map<String,Object> map=new HashMap<String,Object>();
+//        map.put("code", 200);
+//        map.put("info", "业务数据---------1004");
+//        return map;
+//    }
+//     
+//    public Map<String,Object> getInfoFallback() throws InterruptedException{
+//        Map<String,Object> map=new HashMap<String,Object>();
+//        map.put("code", 500);
+//        map.put("info", "系统出错，稍后重试1004");
+//        return map;
+//    }
+    
+    /**
+     * 	模拟hystrix熔断降级处理访问错误
      * @return
      * @throws InterruptedException 
      */
     @ResponseBody
     @GetMapping(value="/getInfo")
-    @HystrixCommand(fallbackMethod="getInfoFallback")
     public Map<String,Object> getInfo() throws InterruptedException{
-        Thread.sleep(1000);
-        Map<String,Object> map=new HashMap<String,Object>();
-        map.put("code", 200);
-        map.put("info", "业务数据---------1004");
-        return map;
-    }
-     
-    public Map<String,Object> getInfoFallback() throws InterruptedException{
-        Map<String,Object> map=new HashMap<String,Object>();
-        map.put("code", 500);
-        map.put("info", "系统出错，稍后重试1004");
-        return map;
+        Thread.sleep(900);
+        return studentService.getInfo();
     }
 }

--- a/springcloud_student_parent/springcloud_student_provider_hystrix_1004/src/main/java/com/etjava/service/StudentService.java
+++ b/springcloud_student_parent/springcloud_student_provider_hystrix_1004/src/main/java/com/etjava/service/StudentService.java
@@ -1,33 +1,40 @@
 package com.etjava.service;
 
 import java.util.List;
+import java.util.Map;
 
 import com.etjava.entity.Student;
 
 public interface StudentService {
 
 	 /**
-     * 添加或者修改学生信息
+     *	 添加或者修改学生信息
      * @param student
      */
     public void save(Student student);
      
     /**
-     * 根据id查找学生信息
+     *	 根据id查找学生信息
      * @param id
      * @return
      */
     public Student findById(Integer id);
      
     /**
-     * 查询学生信息
+     *	 查询学生信息
      * @return
      */
     public List<Student> list();
      
     /**
-     * 根据id删除学生信息
+     * 	根据id删除学生信息
      * @param id
      */
     public void delete(Integer id);
+    
+    /**
+     * 	测试 hystrix 服务熔断降级的方法
+     * @return
+     */
+    public Map<String,Object> getInfo();
 }

--- a/springcloud_student_parent/springcloud_student_provider_hystrix_1004/src/main/java/com/etjava/service/StudentServiceImpl.java
+++ b/springcloud_student_parent/springcloud_student_provider_hystrix_1004/src/main/java/com/etjava/service/StudentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.etjava.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 
@@ -33,5 +35,13 @@ public class StudentServiceImpl implements StudentService{
 	@Override
 	public void delete(Integer id) {
 		studentRepository.delete(id);
+	}
+
+	@Override
+	public Map<String, Object> getInfo() {
+		Map<String,Object> map=new HashMap<String,Object>();
+	    map.put("code", 200);
+	    map.put("info", "业务数据-----------1004");
+	    return map;
 	}
 }

--- a/springcloud_student_parent/springcloud_student_provider_hystrix_1005/src/main/java/com/etjava/controller/StudentController.java
+++ b/springcloud_student_parent/springcloud_student_provider_hystrix_1005/src/main/java/com/etjava/controller/StudentController.java
@@ -84,21 +84,28 @@ public class StudentController {
      * @return
      * @throws InterruptedException 
      */
+//    @ResponseBody
+//    @GetMapping(value="/getInfo")
+//    @HystrixCommand(fallbackMethod="getInfoFallback")
+//    public Map<String,Object> getInfo() throws InterruptedException{
+//        Thread.sleep(1000);
+//        Map<String,Object> map=new HashMap<String,Object>();
+//        map.put("code", 200);
+//        map.put("info", "业务数据---------1005");
+//        return map;
+//    }
+//     
+//    public Map<String,Object> getInfoFallback() throws InterruptedException{
+//        Map<String,Object> map=new HashMap<String,Object>();
+//        map.put("code", 500);
+//        map.put("info", "系统出错，稍后重试 1005");
+//        return map;
+//    }
+    
     @ResponseBody
     @GetMapping(value="/getInfo")
-    @HystrixCommand(fallbackMethod="getInfoFallback")
     public Map<String,Object> getInfo() throws InterruptedException{
-        Thread.sleep(1000);
-        Map<String,Object> map=new HashMap<String,Object>();
-        map.put("code", 200);
-        map.put("info", "业务数据---------1005");
-        return map;
-    }
-     
-    public Map<String,Object> getInfoFallback() throws InterruptedException{
-        Map<String,Object> map=new HashMap<String,Object>();
-        map.put("code", 500);
-        map.put("info", "系统出错，稍后重试 1005");
-        return map;
+        Thread.sleep(2000);
+        return studentService.getInfo();
     }
 }

--- a/springcloud_student_parent/springcloud_student_provider_hystrix_1005/src/main/java/com/etjava/service/StudentService.java
+++ b/springcloud_student_parent/springcloud_student_provider_hystrix_1005/src/main/java/com/etjava/service/StudentService.java
@@ -1,33 +1,40 @@
 package com.etjava.service;
 
 import java.util.List;
+import java.util.Map;
 
 import com.etjava.entity.Student;
 
 public interface StudentService {
 
 	 /**
-     * 添加或者修改学生信息
+     * 	添加或者修改学生信息
      * @param student
      */
     public void save(Student student);
      
     /**
-     * 根据id查找学生信息
+     * 	根据id查找学生信息
      * @param id
      * @return
      */
     public Student findById(Integer id);
      
     /**
-     * 查询学生信息
+     * 	查询学生信息
      * @return
      */
     public List<Student> list();
      
     /**
-     * 根据id删除学生信息
+     * 	根据id删除学生信息
      * @param id
      */
     public void delete(Integer id);
+    
+    /**
+     * 	测试 hystrix 服务熔断降级的方法
+     * @return
+     */
+    public Map<String,Object> getInfo();
 }

--- a/springcloud_student_parent/springcloud_student_provider_hystrix_1005/src/main/java/com/etjava/service/StudentServiceImpl.java
+++ b/springcloud_student_parent/springcloud_student_provider_hystrix_1005/src/main/java/com/etjava/service/StudentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.etjava.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 
@@ -33,5 +35,13 @@ public class StudentServiceImpl implements StudentService{
 	@Override
 	public void delete(Integer id) {
 		studentRepository.delete(id);
+	}
+
+	@Override
+	public Map<String, Object> getInfo() {
+		Map<String,Object> map=new HashMap<String,Object>();
+	    map.put("code", 200);
+	    map.put("info", "业务数据-----------1005");
+	    return map;
 	}
 }


### PR DESCRIPTION
Feign与Hystrix整合实现业务解耦
在模拟hystrix熔断机制时 为了省事 直接将模拟的方法(getInfo) 放在了Controller中，正常的业务流程应该是在service中，这里通过Feigin实现业务接口的分离，然后通过Hystrix的熔断和服务降级机制(通过实现FallbackFactory接口方式)  两个的组合使用 实现业务彻底解耦